### PR TITLE
fix links without http prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@
 
 ## modular css projects
 
-- [basscss](npmjs.org/basscss)
-- [tachyons](npmjs.org/tachyons)
-- [suitcss](npmjs.org/suitcss)
-- [topcoat](npmjs.org/topcoat)
-- [csskit](npmjs.org/csskit)
+- [basscss](http://npmjs.org/basscss)
+- [tachyons](http://npmjs.org/tachyons)
+- [suitcss](http://npmjs.org/suitcss)
+- [topcoat](http://npmjs.org/topcoat)
+- [csskit](http://npmjs.org/csskit)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -331,11 +331,11 @@ window.onload = function() {
 </div>
 <div><h2 id="modular-css-projects">modular css projects</h2>
 <ul>
-<li><a href="npmjs.org/basscss">basscss</a></li>
-<li><a href="npmjs.org/tachyons">tachyons</a></li>
-<li><a href="npmjs.org/suitcss">suitcss</a></li>
-<li><a href="npmjs.org/topcoat">topcoat</a></li>
-<li><a href="npmjs.org/csskit">csskit</a></li>
+<li><a href="http://npmjs.org/basscss">basscss</a></li>
+<li><a href="http://npmjs.org/tachyons">tachyons</a></li>
+<li><a href="http://npmjs.org/suitcss">suitcss</a></li>
+<li><a href="http://npmjs.org/topcoat">topcoat</a></li>
+<li><a href="http://npmjs.org/csskit">csskit</a></li>
 </ul>
 </div>
 <div><h2 id="preprocessors-">preprocessors?</h2>


### PR DESCRIPTION
otherwise they point to places like `https://github.com/sethvincent/css-via-npm/blob/gh-pages/npmjs.org/basscss`
